### PR TITLE
fix: Use configured timezone (Paperless, Picard, Posterizarr)

### DIFF
--- a/services/paperless/compose.yml
+++ b/services/paperless/compose.yml
@@ -73,7 +73,7 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/Amsterdam
+      - TZ=${TZ}
       - PAPERLESS_TIME_ZONE=${PAPERLESS_TIME_ZONE}
       - PAPERLESS_OCR_LANGUAGE=${PAPERLESS_OCR_LANGUAGE}
       - PAPERLESS_SECRET_KEY=${PAPERLESS_SECRET_KEY}
@@ -92,7 +92,7 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/Amsterdam
+      - TZ=${TZ}
       - POSTGRES_DB=paperless
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -105,4 +105,4 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/Amsterdam
+      - TZ=${TZ}

--- a/services/picard/compose.yaml
+++ b/services/picard/compose.yaml
@@ -55,7 +55,7 @@ services:
     environment:
       - USER_ID=1000
       - GROUP_ID=1000
-      - TZ=Europe/Amsterdam # Change according to your timezone or set by mapping /etc/localtime between the host and the container.
+      - TZ=${TZ}
     volumes:
       - ./${SERVICE}-data/config:/config:rw
       - ./${SERVICE}-data/music:/storage:rw

--- a/services/posterizarr/compose.yaml
+++ b/services/posterizarr/compose.yaml
@@ -53,7 +53,7 @@ services:
     network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
     container_name: app-${SERVICE} # Name for local container management
     environment:
-      - TZ=Europe/Amsterdam 
+      - TZ=${TZ}
       - TERM=xterm 
       - RUN_TIME=disabled 
     user: "1000:1000" 


### PR DESCRIPTION
## Description

Replace hardcoded `TZ=Europe/Amsterdam` values with `TZ=${TZ}` in the Paperless, Picard, and Posterizarr Compose configurations. This makes each stack honor the timezone configured in its `.env` file and aligns these services with the repository template.

Paperless-specific `PAPERLESS_TIME_ZONE` configuration is unchanged.

## Related Issues

- None.

## Verification

- `docker compose config --quiet` in `services/paperless`
- `docker compose config --quiet` in `services/picard`
- `docker compose config --quiet` in `services/posterizarr`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] I have performed a self-review of my code and followed the [templates](https://github.com/tailscale-dev/ScaleTail/tree/main/templates/service-template) structure.
- [x] I have added verification that the stack works as expected.
- [x] I have reviewed documentation requirements; no documentation changes are needed for this configuration fix.
- [ ] A maintainer needs to select the appropriate label because external contributors cannot apply upstream labels.

## Additional Context

- None.