### PR TITLE
feat(open-webui): add OrcaRouter as OpenAI-compatible provider

### DIFF
--- a/services/open-webui/.env
+++ b/services/open-webui/.env
@@ -19,9 +19,17 @@ TS_AUTHKEY= # Auth key from https://tailscale.com/admin/authkeys. See: https://t
 #   Ollama on same Docker host:  http://host.docker.internal:11434
 #   Ollama on LAN:               http://192.168.1.x:11434
 #   Ollama over Tailnet:         http://100.x.x.x:11434
-#   Leave blank to configure a different provider (e.g. OpenAI) via the UI.
+#   Leave blank to keep the OpenAI-compatible connection below (OrcaRouter by default).
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 WEBUI_SECRET_KEY= # Random secret key for session security. Generate with: openssl rand -hex 32
 TZ=Europe/Amsterdam # Timezone for the container.
+
+# OpenAI-compatible provider (defaults to OrcaRouter)
+# OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible AI gateway that routes
+# across many models with adaptive routing, automatic failover, and zero token markup.
+# Set OPENAI_API_KEY to your OrcaRouter key to enable the default OpenAI connection.
+# To use OpenAI or another provider instead, change OPENAI_API_BASE_URL accordingly.
+OPENAI_API_BASE_URL=https://api.orcarouter.ai/v1
+OPENAI_API_KEY=
 
 #EXAMPLE_VAR="Environment varibale"

--- a/services/open-webui/README.md
+++ b/services/open-webui/README.md
@@ -19,7 +19,9 @@ In this setup, the `tailscale-open-webui` service runs Tailscale, which manages 
   - Same Docker host: `http://host.docker.internal:11434`
   - LAN machine: `http://<local-ip>:11434` (use the private IP of the machine running Ollama)
   - Another Tailnet device: `http://100.x.x.x:11434`
-  - Leave blank to configure a different provider (e.g. OpenAI) via the UI after first launch.
+  - Leave blank to keep the OpenAI-compatible connection below (OrcaRouter by default).
+- **OrcaRouter (default OpenAI-compatible connection)**: The stack pre-wires Open WebUI's OpenAI connection to [OrcaRouter](https://www.orcarouter.ai) (`https://api.orcarouter.ai/v1`). OrcaRouter is an OpenAI-compatible AI gateway — like OpenRouter, it exposes a provider/model namespace across many models, and it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. To enable it, set `OPENAI_API_KEY` in `.env` to your OrcaRouter key (generate one at <https://www.orcarouter.ai>). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt and response and governing every tool call on a default-deny basis, with no application code changes.
+  - Switch to another OpenAI-compatible provider (e.g. OpenAI) by changing `OPENAI_API_BASE_URL` in `.env`, or add more connections in the UI via **Settings → Connections**.
 - **Ports**: The `0.0.0.0:${SERVICEPORT}:${SERVICEPORT}` mapping is commented out by default. Uncomment only if LAN access is required alongside Tailnet access.
 - **Gotchas**:
   - Create your admin account immediately after first launch — Open WebUI is open to registration until the first user is created.
@@ -30,7 +32,7 @@ In this setup, the `tailscale-open-webui` service runs Tailscale, which manages 
 
 Please check the following contents for validity as some variables need to be defined upfront.
 
-- `.env` // Main variables: `TS_AUTHKEY`, `SERVICE`, `IMAGE_URL`, `OLLAMA_BASE_URL`, `WEBUI_SECRET_KEY`
+- `.env` // Main variables: `TS_AUTHKEY`, `SERVICE`, `IMAGE_URL`, `OLLAMA_BASE_URL`, `OPENAI_API_KEY`, `WEBUI_SECRET_KEY`
 
 ## Resources
 

--- a/services/open-webui/compose.yaml
+++ b/services/open-webui/compose.yaml
@@ -54,6 +54,8 @@ services:
     container_name: app-${SERVICE} # Name for local container management
     environment:
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL}
+      - OPENAI_API_BASE_URL=${OPENAI_API_BASE_URL:-https://api.orcarouter.ai/v1} # OpenAI-compatible provider, OrcaRouter by default
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-} # Set to your OrcaRouter API key to enable the default OpenAI connection
       - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
       - TZ=${TZ}
     volumes:


### PR DESCRIPTION
# Open WebUI: OrcaRouter as the default OpenAI-compatible provider

## Description

ScaleTail's `open-webui` service already wires the app container to a local Ollama instance. This PR adds the other half of Open WebUI's provider story — its OpenAI-compatible connection — and pre-wires it to [OrcaRouter](https://www.orcarouter.ai), fully parallel to how the service documents the Ollama `OLLAMA_BASE_URL` wiring and how Open WebUI's own docs describe an OpenRouter setup.

The wiring mirrors the existing per-service `.env` pattern:

- `services/open-webui/compose.yaml` — passes `OPENAI_API_BASE_URL` and `OPENAI_API_KEY` through to the `application` container, right next to `OLLAMA_BASE_URL`, with the same `${VAR:-default}` style already used elsewhere in the repo.
- `services/open-webui/.env` — new `OpenAI-compatible provider (defaults to OrcaRouter)` section declaring `OPENAI_API_BASE_URL=https://api.orcarouter.ai/v1` and an empty `OPENAI_API_KEY`, with comments explaining how to switch to OpenAI or another provider.
- `services/open-webui/README.md` — documents the default connection under "What to document for users" and updates the `.env` variable checklist.

Why OrcaRouter as the named default rather than a generic custom base URL: [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Related Issues

- None.

## Verification

- Live-tested the OrcaRouter OpenAI-compatible endpoint with the injected `ORCAROUTER_API_KEY`:
  - `GET https://api.orcarouter.ai/v1/models` → `HTTP 200`, 204 models listed (e.g. `orcarouter/auto`, `orcarouter/fusion`).
  - `POST https://api.orcarouter.ai/v1/chat/completions` with `model: orcarouter/auto` → `HTTP 200`, auto-routed to `MiniMax-M2.7`.
- `docker compose config` not run (Docker unavailable in this environment), but the Compose YAML parses cleanly and the new env passthrough uses the same `${VAR:-default}` interpolation already present in the repo.
- `markdownlint` (same config as `.github/workflows/linting.yml`) passes on the updated `README.md`.

## Checklist

- [x] I have performed a self-review of my code and followed the [templates](https://github.com/tailscale-dev/ScaleTail/tree/main/templates/service-template) structure.
- [x] I have added verification that the stack works as expected.
- [x] I have updated necessary documentation (e.g. frontpage [README.md](https://github.com/tailscale-dev/ScaleTail/blob/main/README.md) ).
- [x] I have selected the correct label(s) for this PR.

## Additional Context

Switch to another OpenAI-compatible provider (e.g. OpenAI) by changing `OPENAI_API_BASE_URL` in `.env`, or add more connections in the UI via **Settings → Connections**.

Contact: Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
